### PR TITLE
Fix SNS identification bug

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lambdr
 Title: Create a Runtime for Serving Containerised R Functions on 'AWS Lambda'
-Version: 1.2.0
+Version: 1.2.1
 Authors@R: 
     c(person(given = "David",
              family = "Neuzerling",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# lambdr 1.2.1
+
+* Fixed a bug that was preventing `lambdr` from identifying events coming from
+  AWS SNS.
+
 # lambdr 1.2.0
 
 * Added `html_response` for sending bespoke responses to API Gateways.

--- a/R/sns-events.R
+++ b/R/sns-events.R
@@ -8,7 +8,7 @@
 #' @return logical
 #' @keywords internal
 is_sns_event_content <- function(event_content) {
-  grepl('"EventSource":"aws:sns"', event_content)
+  grepl('"EventSource": "aws:sns"', event_content)
 }
 
 #' @export

--- a/tests/testthat/test-sns-events.R
+++ b/tests/testthat/test-sns-events.R
@@ -11,7 +11,7 @@ test_that("SNS events are detected", {
     is_sns_event_content(
       as_stringified_json(
         list(EventSource = "aws:sns"),
-        pretty = FALSE
+        pretty = TRUE
       )
     )
   )


### PR DESCRIPTION
Closes #16

Fixed a bug that was preventing `lambdr` from identifying events coming from AWS SNS.