### PR TITLE
Default to formatter_paste

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Runtime for serving containers that can execute R code on the
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1
 Imports: 
     httr,
     jsonlite,

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed a bug that was preventing `lambdr` from identifying events coming from
   AWS SNS.
+* Default to the `formatter_paste` log formatter instead of `formatter_glue`, 
+  which can cause issues when logging JSON objects.
 
 # lambdr 1.2.0
 

--- a/R/start-lambda.R
+++ b/R/start-lambda.R
@@ -41,6 +41,13 @@
 #' }
 start_lambda <- function(config = lambda_config(environ = parent.frame()),
                          timeout_seconds = NULL) {
+
+  # We're logging JSONs, which means lots of braces. The glue formatter won't
+  # work here.
+  if (identical(logger::log_formatter(), parse(text = "formatter_glue")[[1]])) {
+    logger::log_formatter(logger::formatter_paste)
+  }
+
   start_listening(
     config = config,
     timeout_seconds = timeout_seconds

--- a/man/handle_event_error.Rd
+++ b/man/handle_event_error.Rd
@@ -24,7 +24,9 @@ that the runtime moves onto the next event.
 
 This function may need to be implemented differently depending on the source
 of an event. As such, \code{handle_event_error} is an S3 generic that can dispatch
-on the event class as returned by \code{\link{classify_event}}.\if{html}{\out{<div class="sourceCode r">}}\preformatted{tryCatch(
+on the event class as returned by \code{\link{classify_event}}.
+
+\if{html}{\out{<div class="sourceCode r">}}\preformatted{tryCatch(
     handle_event(...),
     error = handle_invocation_error(event) # returns a function(e)
  )

--- a/man/html_response.Rd
+++ b/man/html_response.Rd
@@ -41,7 +41,9 @@ A stringified JSON response for an API Gateway, with the
 }
 \description{
 Lambdas behind API Gateways need to send specially formatted responses that
-look like this:\if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
+look like this:
+
+\if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
   "statusCode": 200,
   "headers": \{
     "Content-Type": "application/json"

--- a/man/post_lambda_error.Rd
+++ b/man/post_lambda_error.Rd
@@ -16,7 +16,9 @@ According to the
 \href{https://docs.aws.amazon.com/lambda/latest/dg/lambda-dg.pdf}{AWS Lambda
 Developer Guide} an error posted to the initialisation or invocation error
 endpoints must be of content type \code{application/vnd.aws.lambda.error+json}
-and of the format:\if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
+and of the format:
+
+\if{html}{\out{<div class="sourceCode json">}}\preformatted{\{
   "errorMessage": "...",
   "errorType": "...",
   "stackTrace": [],


### PR DESCRIPTION
Default to the `formatter_paste` log formatter instead of `formatter_glue`, which can cause issues when logging JSON objects.