### PR TITLE
Fix missing space in docs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lambdr
 Title: Create a Runtime for Serving Containerised R Functions on 'AWS Lambda'
-Version: 1.2.3
+Version: 1.2.4
 Authors@R: 
     c(person(given = "David",
              family = "Neuzerling",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lambdr 1.2.4
+
+* Fixed incorrect argument name in internal documentation.
+
 # lambdr 1.2.3
 
 * Removed all verbatim chunks (marked by three backticks) in help docs, to meet

--- a/R/extract-context.R
+++ b/R/extract-context.R
@@ -28,7 +28,7 @@ extract_context_from_environment <- function() {
 #'
 #' @inheritParams handle_event
 #' @inheritParams validate_lambda_config
-#' @param ...additional arguments passed to \code{\link{extract_context}}
+#' @param ... additional arguments passed to \code{\link{extract_context}}
 #'
 #' @inheritSection extract_context Event context
 #'

--- a/man/extract_and_augment_context.Rd
+++ b/man/extract_and_augment_context.Rd
@@ -13,7 +13,7 @@ endpoint.}
 \item{config}{A list of configuration values as created by the
 \code{lambda_config} function.}
 
-\item{...additional}{arguments passed to \code{\link{extract_context}}}
+\item{...}{additional arguments passed to \code{\link{extract_context}}}
 }
 \value{
 list


### PR DESCRIPTION
# lambdr 1.2.4

* Fixed incorrect argument name in internal documentation.
