### PR TITLE
Pass environment to lambda_config

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lambdr
 Title: Create a Runtime for Serving Containerised R Functions on 'AWS Lambda'
-Version: 1.2.5
+Version: 1.2.6
 Authors@R: 
     c(person(given = "David",
              family = "Neuzerling",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lambdr 1.2.6
+
+* Fixed an issue with a test helper that was causing tests to fail.
+
 # lambdr 1.2.5
 
 * Update docs to include information on Docker tags.

--- a/tests/testthat/helper-test-helpers.R
+++ b/tests/testthat/helper-test-helpers.R
@@ -39,10 +39,7 @@ basic_lambda_config <- function(handler = "sqrt",
   }
 
   withr::with_envvar(env_vars,
-    withr::with_environment(
-      parent.frame(),
-      lambda_config(handler = direct_handler, ...)
-    )
+    lambda_config(handler = direct_handler, environ = parent.frame(), ...)
   )
 }
 


### PR DESCRIPTION
Closes #40 

The previous test helper code set up a lambdr like so:

```r
  withr::with_envvar(env_vars,
    withr::with_environment(
      parent.frame(),
      lambda_config(handler = direct_handler, ...)
    )
  )
```

The `lambda_config` would then pick up on the environment through the `parent.frame` function. For some reason, this wasn't happening, and the environment of the test helper function was being picked up instead.

Given that the `lambda_config` function already accepted an `environ` argument, I decided to just use this instead. The new code is thus:

```r
  withr::with_envvar(env_vars,
    lambda_config(handler = direct_handler, environ = parent.frame(), ...)
  )
```