### PR TITLE
Move away from webmockr::RequestPattern

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
 Suggests: 
     withr,
     testthat (>= 3.0.0),
-    webmockr,
+    webmockr (>= 2.1.1.91),
     knitr,
     rmarkdown,
     lifecycle

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     knitr,
     rmarkdown,
     lifecycle
+Remotes: ropensci/webmockr
 Config/testthat/edition: 3
 URL: https://lambdr.mdneuzerling.com/,
     https://github.com/mdneuzerling/lambdr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: lambdr
 Title: Create a Runtime for Serving Containerised R Functions on 'AWS Lambda'
-Version: 1.2.6
+Version: 1.2.7
 Authors@R: 
     c(person(given = "David",
              family = "Neuzerling",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# lambdr 1.2.7
+
+* Removed webmockr::RequestPattern from all unit tests.
+
 # lambdr 1.2.6
 
 * Fixed an issue with a test helper that was causing tests to fail.

--- a/tests/testthat/helper-html-api-gateway-test-helpers.R
+++ b/tests/testthat/helper-html-api-gateway-test-helpers.R
@@ -49,11 +49,7 @@ mock_html_api_gateway_event <- function(query_parameters = NULL,
   start_listening(config = config, timeout_seconds = timeout_seconds)
 
   requests <- webmockr::request_registry()
-  n_responses <- requests$times_executed(
-    webmockr::RequestPattern$new("post", response_endpoint)
-  )
-
-  n_responses >= 1
+  request_received("post", response_endpoint)
 }
 
 mock_html_api_gateway_event_body <- function(query_parameters = NULL,

--- a/tests/testthat/helper-rest-api-gateway-test-helpers.R
+++ b/tests/testthat/helper-rest-api-gateway-test-helpers.R
@@ -48,12 +48,7 @@ mock_rest_api_gateway_event <- function(query_parameters = NULL,
 
   start_listening(config = config, timeout_seconds = timeout_seconds)
 
-  requests <- webmockr::request_registry()
-  n_responses <- requests$times_executed(
-    webmockr::RequestPattern$new("post", response_endpoint)
-  )
-
-  n_responses >= 1
+  request_received("post", response_endpoint)
 }
 
 mock_rest_api_gateway_event_body <- function(query_parameters = NULL,

--- a/tests/testthat/test-start-listening.R
+++ b/tests/testthat/test-start-listening.R
@@ -123,12 +123,9 @@ test_that("error occurs when request ID not in headers", {
     NA
   )
 
-  requests <- webmockr::request_registry()
-  n_responses <- requests$times_executed(
-    webmockr::RequestPattern$new("get", invocation_endpoint)
-  )
-
   # Should be more than 1 invocation, to prove the runtime didn't hang on one
   # failed invocation without a request_id
-  n_responses > 1
+  expect_true(
+    request_received("get", invocation_endpoint, min_requests = 2)
+  )
 })


### PR DESCRIPTION
Moves all tests away from using `webmockr::RequestPattern`.

The new approach uses `webmockr::request_registry_filter` which requires the latest version of webmockr

Closes #43.